### PR TITLE
Fix support for custom discord clients

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-from .config import CLIENT_ID, HYTALE_LOG_DIR, HYTALE_PROCESS_NAMES, DISCORD_PROCESS_NAMES
+from .config import CLIENT_ID, HYTALE_LOG_DIR, HYTALE_PROCESS_NAMES
 from .process import is_process_running, get_process_start_time
 from .log_watcher import LogWatcher
 from .rpc import HytaleRPC

--- a/src/config.py
+++ b/src/config.py
@@ -40,7 +40,3 @@ HYTALE_PROCESS_NAMES = [
     "hytalelauncher", "hytalelauncher.exe", "hytale-launcher",
 ]
 
-DISCORD_PROCESS_NAMES = [
-    "discord", "discord.exe", "discordcanary", "discordcanary.exe",
-    "discordptb", "discordptb.exe",
-]

--- a/src/config_macos.py
+++ b/src/config_macos.py
@@ -15,8 +15,3 @@ HYTALE_PROCESS_NAMES = [
     "hytale", "hytale.exe", "hytaleclient", "hytaleclient.exe",
     "hytalelauncher", "hytalelauncher.exe", "hytale-launcher",
 ]
-
-DISCORD_PROCESS_NAMES = [
-    "discord", "discord.exe", "discordcanary", "discordcanary.exe",
-    "discordptb", "discordptb.exe",
-]

--- a/src/config_windows.py
+++ b/src/config_windows.py
@@ -15,8 +15,3 @@ HYTALE_PROCESS_NAMES = [
     "hytale", "hytale.exe", "hytaleclient", "hytaleclient.exe",
     "hytalelauncher", "hytalelauncher.exe", "hytale-launcher",
 ]
-
-DISCORD_PROCESS_NAMES = [
-    "discord", "discord.exe", "discordcanary", "discordcanary.exe",
-    "discordptb", "discordptb.exe",
-]

--- a/src/rpc.py
+++ b/src/rpc.py
@@ -1,6 +1,7 @@
 import time
 from pypresence import Presence
-from .config import CLIENT_ID, HYTALE_PROCESS_NAMES, DISCORD_PROCESS_NAMES
+from pypresence.utils import get_ipc_path
+from .config import CLIENT_ID, HYTALE_PROCESS_NAMES
 from .process import is_process_running, get_process_start_time
 from .log_watcher import LogWatcher
 
@@ -75,7 +76,7 @@ class HytaleRPC:
         self.set_status("Waiting for Hytale...")
 
         while self.running:
-            discord_on = is_process_running(DISCORD_PROCESS_NAMES)
+            discord_on = True if get_ipc_path() else False
             hytale_on = is_process_running(HYTALE_PROCESS_NAMES)
 
             if hytale_on and discord_on and not rpc_active:

--- a/src/rpc_macos.py
+++ b/src/rpc_macos.py
@@ -1,11 +1,12 @@
 import time
 import platform
 from pypresence import Presence
+from pypresence.utils import get_ipc_path
 if platform.system() == "Darwin":
-    from .config_macos import CLIENT_ID, HYTALE_PROCESS_NAMES, DISCORD_PROCESS_NAMES
+    from .config_macos import CLIENT_ID, HYTALE_PROCESS_NAMES
     from .log_watcher_macos import LogWatcher
 else:
-    from .config import CLIENT_ID, HYTALE_PROCESS_NAMES, DISCORD_PROCESS_NAMES
+    from .config import CLIENT_ID, HYTALE_PROCESS_NAMES
     from .log_watcher import LogWatcher
 from .process import is_process_running, get_process_start_time
 
@@ -80,7 +81,7 @@ class HytaleRPC:
         self.set_status("Waiting for Hytale...")
 
         while self.running:
-            discord_on = is_process_running(DISCORD_PROCESS_NAMES)
+            discord_on = True if get_ipc_path() else False
             hytale_on = is_process_running(HYTALE_PROCESS_NAMES)
 
             if hytale_on and discord_on and not rpc_active:

--- a/src/rpc_windows.py
+++ b/src/rpc_windows.py
@@ -1,14 +1,15 @@
 import time
 import platform
 from pypresence import Presence
+from pypresence.utils import get_ipc_path
 if platform.system() == "Darwin":
-    from .config_macos import CLIENT_ID, HYTALE_PROCESS_NAMES, DISCORD_PROCESS_NAMES
+    from .config_macos import CLIENT_ID, HYTALE_PROCESS_NAMES
     from .log_watcher_macos import LogWatcher
 elif platform.system() == "Windows":
-    from .config_windows import CLIENT_ID, HYTALE_PROCESS_NAMES, DISCORD_PROCESS_NAMES
+    from .config_windows import CLIENT_ID, HYTALE_PROCESS_NAMES
     from .log_watcher_windows import LogWatcher
 else:
-    from .config import CLIENT_ID, HYTALE_PROCESS_NAMES, DISCORD_PROCESS_NAMES
+    from .config import CLIENT_ID, HYTALE_PROCESS_NAMES
     from .log_watcher import LogWatcher
 from .process import is_process_running, get_process_start_time
 
@@ -83,7 +84,7 @@ class HytaleRPC:
         self.set_status("Waiting for Hytale...")
 
         while self.running:
-            discord_on = is_process_running(DISCORD_PROCESS_NAMES)
+            discord_on = True if get_ipc_path() else False
             hytale_on = is_process_running(HYTALE_PROCESS_NAMES)
 
             if hytale_on and discord_on and not rpc_active:


### PR DESCRIPTION
This change replaces the built-in process checking system for a running discord client. The current system only checks for official discord client processes. However, some people use unofficial discord clients like Vesktop, Vencord, betterdiscord, etc., so this app doesn't work with them as it can't find the discord process.

By checking the IPC path instead, we can find any running discord clients.

Only tested on Linux (CachyOS) with Vesktop, don't know about support for other systems and clients, but they should work as well.